### PR TITLE
Re-enable main branch protection in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,9 +45,9 @@ repos:
       - id: end-of-file-fixer
       # Trim trailing whitespace
       - id: trailing-whitespace
-      # Prevent commits to main branch (disabled for initial commit)
-      # - id: no-commit-to-branch
-      #   args: [--branch, main, --branch, master]
+      # Prevent commits to main branch
+      - id: no-commit-to-branch
+        args: [--branch, main, --branch, master]
       # Check for merge conflict markers
       - id: check-merge-conflict
       # Check for case conflicts in filenames


### PR DESCRIPTION
## Summary

Re-enable `no-commit-to-branch` hook in `.pre-commit-config.yaml` to prevent direct commits to `main` branch.

## Changes

- `.pre-commit-config.yaml`: Uncommented `no-commit-to-branch` hook that was temporarily disabled for initial commit

## Context

This hook was temporarily disabled during initial commit setup to allow the first commit to `main`. Now that the initial commit is pushed, we re-enable the protection to enforce feature branch workflow.

## Testing

- ✅ Pre-commit hooks pass on feature branch
- ✅ Attempting to commit directly to `main` now fails with `no-commit-to-branch` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)